### PR TITLE
includes maxPercent PropType to React Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ export default class App extends Component {
       <View style={styles.container}>
         <Text>{this.state.status}</Text>
         <ScratchCard
+          brushSize={125}
           getPercent={(percent) => {
             this.setState({ status: percent })
           }}
           onEnd={() => { Alert.alert('acabou!') }}
           maxPercent={50}
           style={{ justifyContent: 'center', alignItems: 'center', width: 400, height: 400 }}
-          color={'gray'}>
+          color={'gray'}
+         >
           <Image source={require('./reactImage.png')} resizeMode="contain" />
         </ScratchCard>
       </View>

--- a/android/src/main/java/com/thebylito/RNScratchCardManager.java
+++ b/android/src/main/java/com/thebylito/RNScratchCardManager.java
@@ -61,6 +61,11 @@ public class RNScratchCardManager extends ViewGroupManager<FrameLayout> {
     public void setMaxPercent(FrameLayout view, Integer percent) {
         scratchView.setMaxPercent(percent);
     }
+    
+    @ReactProp(name = "brushSize")
+    public void setBrushSize(FrameLayout view, Integer size) {
+        scratchView.setEraserSize(size);
+    }
 
     private void emitPan(Integer valor) {
         WritableMap args = Arguments.createMap();

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const { RNScratchCard } = NativeModules;
 const iface = {
   name: 'RNScratchCardManager',
   propTypes: {
+    brushSize: PropTypes.number,
     color: PropTypes.string,
     maxPercent: PropTypes.number,
     ...ViewPropTypes


### PR DESCRIPTION
Fixes a red error appears due to the maxPercent proptype not being included within the React class.
SDK26, Galaxy S8.

Adds BrushSize method to connect with ScratchView eraseSize method.
Also adds respective propTypes to the react class, as well as the readme.